### PR TITLE
Update statistics in smaller batches

### DIFF
--- a/android/app/src/main/java/org/koreader/backgroundonyxsynckoreader/contentprovider/OnyxStatisticsContentProvider.java
+++ b/android/app/src/main/java/org/koreader/backgroundonyxsynckoreader/contentprovider/OnyxStatisticsContentProvider.java
@@ -118,6 +118,8 @@ public class OnyxStatisticsContentProvider {
         public boolean hideRecord = false;
     }
 
+    private static final int CONTENT_PROVIDER_APPLY_BATCH_SIZE = 20;
+
     // -------------------------------------------------------------------------
     // Public API
     // -------------------------------------------------------------------------
@@ -302,7 +304,15 @@ public class OnyxStatisticsContentProvider {
                 return;
             }
 
-            client.applyBatch(ops);
+            for (int i = 0; i < ops.size(); i += CONTENT_PROVIDER_APPLY_BATCH_SIZE) {
+                ArrayList<ContentProviderOperation> batch =
+                        new ArrayList(
+                                ops.subList(i, Math.min(ops.size(), i + CONTENT_PROVIDER_APPLY_BATCH_SIZE))
+                        );
+
+                client.applyBatch(batch);
+            }
+
             Log.i(TAG, "syncBookHistory: inserted " + ops.size()
                     + " missing rows for " + bookPath);
 


### PR DESCRIPTION
Fixes #11 by splitting the updates to the statistics content provider into smaller chunks.

When I tested with the previously failing book I can see that it's been successfully inserted.

```
03-15 22:27:14.695  7717  7717 I OnyxStatisticsProvider: syncBookHistory: inserted 1043 missing rows for /storage/emulated/0/.ksync/NetDisk/WEBDAV/b595cf07bab84b08f87b4b846ea5b1e4/remote.php/dav/files/boox/Calibre/AUTHOR/SERIES/EPUB_TITLE.epub
```